### PR TITLE
fix: making time-offsets take into account ranges

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -103,7 +103,7 @@
   }
 
   function calculateTime(d, offset) {
-    const offsetInHours = Math.floor(offset / 60);
+    const offsetInHours = Math.trunc(offset / 60);
     const remainingOffset = offset % 60;
     let offsetHours = d.getHours() + offsetInHours;
     let offsetMinutes = d.getMinutes() + remainingOffset;
@@ -112,14 +112,14 @@
       offsetMinutes = 60 + offsetMinutes;
     } else if (offsetMinutes > 59) {
       offsetHours++;
-      offsetMinutes = 60 - offsetMinutes;
+      offsetMinutes = offsetMinutes % 60;
     }
     if (offsetHours < 0) {
       d.setDate(d.getDate() - 1);
       offsetHours = 24 + offsetHours;
     } else if (offsetHours > 23) {
       d.setDate(d.getDate() + 1);
-      offsetHours = 24 - offsetHours;
+      offsetHours = offsetHours % 24;
     }
     return `${pad(offsetHours)}:${pad(offsetMinutes)}:${pad(d.getSeconds())}`;
   }
@@ -170,7 +170,7 @@
       val = processNumberOutput();
     }
     active = true;
-    if (sdk && val) {
+    if (sdk && val !== undefined) {
       sdk.field.setValue(val);
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ export function pad(num) {
 export function offsetMinutesToString(num) {
   let negative = num < 0;
   num = Math.abs(num);
-  let hours = pad(Math.floor(num / 60));
+  let hours = pad(Math.trunc(num / 60));
   let minutes = pad(num % 60);
   return `${negative ? '-' : '+'}${hours}:${minutes}`;
 }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfils the following requirements:

- [x] Formatting (`npm run format`) has been applied to the new code.
- [ ] Tests (`npm test`) for the changes have been added (for bug fixes / features).
- [x] PR title and git commit messages conform to the [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) specification.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Local time offsets can create incorrect timestamps.
Setting time to 00:00:00 would not let you save time.

## What is the new behavior?

Hour and minute offsets should effect, day, hour and minutes correctly.
00:00:00 should be a saveable time.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

